### PR TITLE
minor fixes for requirements and jams

### DIFF
--- a/audio_to_midi_melodia.py
+++ b/audio_to_midi_melodia.py
@@ -196,7 +196,7 @@ def audio_to_midi_melodia(infile, outfile, bpm, smooth=0.25, minduration=0.1,
 
     if savejams:
         print("Saving JAMS to disk...")
-        jamsfile = outfile.replace(".mid", ".jams")
+        jamsfile = outfile[:outfile.rfind(".")] + ".jams"
         track_duration = len(data) / float(fs)
         save_jams(jamsfile, notes, track_duration, os.path.basename(infile))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 soundfile
 resampy
+numpy
 vamp
 midiutil
 jams
-numpy
 scipy
 


### PR DESCRIPTION
Requirements install will fail since `vamp` requires `numby`. Reordering fixes this.

Writing JAMS file would fail if midi file extension was not exactly ".mid".